### PR TITLE
Separate lifetime scope injection and component adding

### DIFF
--- a/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
@@ -66,8 +66,42 @@ namespace Owin
             return app;
         }
 
+		/// <summary>
+		/// Adds a middleware to inject request-scoped Autofac lifetime scope into the OWIN pipeline 
+		/// </summary>
+		/// <param name="app">The application builder.</param>
+		/// <param name="container">The Autofac application lifetime scope/container.</param>
+		/// <returns>The application builder.</returns>
 		[SecuritySafeCritical]
-		private static IAppBuilder RegisterAutofacLifetimeScopeInjector(this IAppBuilder app, ILifetimeScope container)
+		public static IAppBuilder UseAutofacLifetimeScopeInjector(this IAppBuilder app, ILifetimeScope container)
+		{
+			if (app == null) throw new ArgumentNullException("app");
+
+			if (app.Properties.ContainsKey(MiddlewareRegisteredKey)) return app;
+
+			app.RegisterAutofacLifetimeScopeInjector(container);
+
+			app.Properties.Add(MiddlewareRegisteredKey, true);
+
+			return app;
+		}
+
+		/// <summary>
+		/// Adds a middleware to the OWIN pipeline that will be constructed using Autofac
+		/// </summary>
+		/// <param name="app">The application builder.</param>
+		/// <returns>The application builder.</returns>
+		[SecuritySafeCritical]
+		public static IAppBuilder UseMiddlewareFromContainer<T>(this IAppBuilder app) where T : OwinMiddleware
+		{
+			if (app == null) throw new ArgumentNullException("app");
+
+			return app.Use<AutofacMiddleware<T>>();
+		}
+
+
+		[SecuritySafeCritical]
+		static IAppBuilder RegisterAutofacLifetimeScopeInjector(this IAppBuilder app, ILifetimeScope container)
 	    {
 		    return app.Use(async (context, next) =>
 		    {

--- a/tests/Autofac.Tests.Integration.Owin/AutofacAppBuilderExtensionsFixture.cs
+++ b/tests/Autofac.Tests.Integration.Owin/AutofacAppBuilderExtensionsFixture.cs
@@ -19,7 +19,8 @@ namespace Autofac.Tests.Integration.Owin
             var container = builder.Build();
             var app = new Mock<IAppBuilder>();
             app.Setup(mock => mock.Properties).Returns(new Dictionary<string, object>());
-            app.Setup(mock => mock.Use(typeof(AutofacMiddleware<TestMiddleware>)));
+			app.Setup(mock => mock.Use(typeof(AutofacMiddleware<TestMiddleware>)));
+			app.SetReturnsDefault(app.Object);
 
             OwinExtensions.UseAutofacMiddleware(app.Object, container);
 


### PR DESCRIPTION
# The problem
I have fairly simple OWIN pipeline:
```
app
	.UseAutofacMiddleware(container)
	.UseBasicAuthentication()
	.Use((c, next) =>
	{
		//authorization
		return next();
	})
	.Use<PathRewriter>
	(
		container.Resolve<EventConverter>(),
		container.Resolve<Func<Guid, BlobStream>>()
	)
	.UseSendFileFallback()
	.UseStaticFiles();
```

I think that you can already spot the weak spot: `Use<PathRewriter>(container.Resolve<EventConverter>(), container.Resolve<Func<Guid, BlobStream>>())`

The thing is, I have to use several middleware components that are not based on `OwinMiddleware` or are registered by other means (like `UseBasicAuthentication`), and, as far as I know `UseAutofacMiddleware` injects all found middleware right after it.

# Proposed solution
Extract two parts, `UseAutofacLifetimeScopeInjector` and `UseMiddlewareFromContainer<T>` from `UseAutofacMiddleware` thus allowing more precise control over pipeline composition. The example from above would be rewritten as:

```
app
	.UseAutofacLifetimeScopeInjector(container)
	.UseBasicAuthentication()
	.Use((c, next) =>
	{
		//authorization
		return next();
	})
	.UseMiddlewareFromContainer<PathRewriter>()
	.UseSendFileFallback()
	.UseStaticFiles();
```