### PR TITLE
External scope injector

### DIFF
--- a/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
@@ -326,6 +326,12 @@ namespace Owin
         {
             app.Use(async (context, next) =>
                 {
+                    if (context.GetAutofacLifetimeScope() != null)
+                    {
+                        await next();
+                        return;
+                    }
+
                     using (var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag,
                     b => b.RegisterInstance(context).As<IOwinContext>()))
                     {

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
@@ -100,6 +100,23 @@ namespace Autofac.Integration.Owin.Test
         }
 
         [Fact]
+        public async void UseAutofacLifetimeScopeInjectorDoesntAddLifetimeScopeToOwinContextIfAlreadyPresent()
+        {
+            var container = new ContainerBuilder().Build();
+
+            using (var server = TestServer.Create(app =>
+            {
+                app.UseAutofacLifetimeScopeInjector(container);
+                //we don't expect anything to be called on this one, so we want it to fail
+                app.UseAutofacLifetimeScopeInjector(new Mock<ILifetimeScope>(MockBehavior.Strict).Object);
+                app.Run(context => context.Response.WriteAsync("Hello, world!"));
+            }))
+            {
+                await server.HttpClient.GetAsync("/");
+            }
+        }
+
+        [Fact]
         public void UseAutofacLifetimeScopeInjectorDoesntAddWrappedMiddlewareInstancesToAppBuilder()
         {
             var builder = new ContainerBuilder();


### PR DESCRIPTION
A proposal for #10: allowing to use external scope in `UseAutofacInjector`.

```
app
  .UseAutofacLifetimeScopeInjector(ctx => SomeLifetimeScopeProvider(ctx))
  .UseMiddlewareFromContainer<PathRewriter>();
```