### PR TITLE
SetAutofacLifetimeScope

### DIFF
--- a/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
@@ -326,6 +326,12 @@ namespace Owin
         {
             app.Use(async (context, next) =>
                 {
+                    if (context.GetAutofacLifetimeScope() != null)
+                    {
+                        await next();
+                        return;
+                    }
+
                     using (var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag,
                     b => b.RegisterInstance(context).As<IOwinContext>()))
                     {

--- a/src/Autofac.Integration.Owin/OwinContextExtensions.cs
+++ b/src/Autofac.Integration.Owin/OwinContextExtensions.cs
@@ -25,5 +25,30 @@ namespace Autofac.Integration.Owin
 
             return context.Get<ILifetimeScope>(Constants.OwinLifetimeScopeKey);
         }
+
+        /// <summary>
+        /// Sets the current Autofac lifetime scope to the OWIN context.
+        /// </summary>
+        /// <param name="context">The OWIN context.</param>
+        /// <param name="scope">The current lifetime scope.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown if <paramref name="context" /> or <paramref name="scope" /> is <see langword="null" />.
+        /// </exception>
+        /// <remarks>The caller is responsible for the appropriate disposal of the passed <see cref="ILifetimeScope"/>.</remarks>
+        public static void SetAutofacLifetimeScope(this IOwinContext context, ILifetimeScope scope)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (scope == null)
+            {
+                throw new ArgumentNullException("scope");
+            }
+
+            context.Set(Constants.OwinLifetimeScopeKey, scope);
+        }
+
     }
 }

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
@@ -117,6 +117,49 @@ namespace Autofac.Integration.Owin.Test
         }
 
         [Fact]
+        public async void UseAutofacLifetimeScopeInjectorDoesntOverrideScopeSetBySetAutofacLifetimeScope()
+        {
+            var lifetimeScope = new TestableLifetimeScope();
+            using (var server = TestServer.Create(app =>
+            {
+                app.Use((ctx, next) =>
+                {
+                    ctx.SetAutofacLifetimeScope(lifetimeScope);
+                    return next();
+                });
+                //we don't expect anything to be called on this one, so we want it to fail
+                app.UseAutofacLifetimeScopeInjector(new Mock<ILifetimeScope>(MockBehavior.Strict).Object);
+                app.Use<TestMiddleware>();
+                app.Run(context => context.Response.WriteAsync("Hello, world!"));
+            }))
+            {
+                await server.HttpClient.GetAsync("/");
+                Assert.Same(lifetimeScope, TestMiddleware.LifetimeScope);
+            }
+        }
+
+        [Fact]
+        public async void UseAutofacLifetimeScopeInjectorDoesntDisposeScopeSetBySetAutofacLifetimeScope()
+        {
+            var lifetimeScope = new TestableLifetimeScope();
+            using (var server = TestServer.Create(app =>
+            {
+                app.Use((ctx, next) =>
+                {
+                    ctx.SetAutofacLifetimeScope(lifetimeScope);
+                    return next();
+                });
+                app.UseAutofacLifetimeScopeInjector(new Mock<ILifetimeScope>(MockBehavior.Strict).Object);
+                app.Use<TestMiddleware>();
+                app.Run(context => context.Response.WriteAsync("Hello, world!"));
+            }))
+            {
+                await server.HttpClient.GetAsync("/");
+            }
+            Assert.False(lifetimeScope.ScopeIsDisposed);
+        }
+
+        [Fact]
         public void UseAutofacLifetimeScopeInjectorDoesntAddWrappedMiddlewareInstancesToAppBuilder()
         {
             var builder = new ContainerBuilder();

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
@@ -100,6 +100,23 @@ namespace Autofac.Integration.Owin.Test
         }
 
         [Fact]
+        public async void UseAutofacLifetimeScopeInjectorDoesntAddLifetimeScopeToOwinContextIfAlreadyPresent()
+        {
+            var container = new ContainerBuilder().Build();
+
+            using (var server = TestServer.Create(app =>
+            {
+                app.UseAutofacLifetimeScopeInjector(container);
+                //we don't expect anything to be called on this one, so we want it to fail
+                app.UseAutofacLifetimeScopeInjector(new Mock<ILifetimeScope>(MockBehavior.Strict).Object);
+                app.Run(context => context.Response.WriteAsync("Hello, world!"));
+            }))
+            {
+                await server.HttpClient.GetAsync("/");
+            }
+        }
+
+        [Fact]
         public void UseAutofacLifetimeScopeInjectorDoesntAddWrappedMiddlewareInstancesToAppBuilder()
         {
             var builder = new ContainerBuilder();

--- a/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Microsoft.Owin;
+using Microsoft.Owin.Testing;
 using Moq;
+using Owin;
 using Xunit;
 
 namespace Autofac.Integration.Owin.Test
@@ -21,6 +23,60 @@ namespace Autofac.Integration.Owin.Test
         {
             var exception = Assert.Throws<ArgumentNullException>(() => OwinContextExtensions.GetAutofacLifetimeScope(null));
             Assert.Equal("context", exception.ParamName);
+        }
+
+        [Fact]
+        public void SetAutofacLifetimeScopeSetsInstanceToContext()
+        {
+            var instance = new Mock<ILifetimeScope>();
+
+            var context = new Mock<IOwinContext>();
+            context.Setup(mock => mock.Set(Constants.OwinLifetimeScopeKey, instance.Object));
+            context.Object.SetAutofacLifetimeScope(instance.Object);
+            context.VerifyAll();
+        }
+
+        [Fact]
+        public void SetAutofacLifetimeScopeThrowsWhenProvidedNullContextInstance()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => OwinContextExtensions.SetAutofacLifetimeScope(null, new Mock<ILifetimeScope>().Object));
+            Assert.Equal("context", exception.ParamName);
+        }
+
+        [Fact]
+        public void SetAutofacLifetimeScopeThrowsWhenProvidedNullScopeInstance()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => OwinContextExtensions.SetAutofacLifetimeScope(new OwinContext(), null));
+            Assert.Equal("scope", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetAutofacLifetimeScopeReturnsTheInstanceFromSetLifetimeScope()
+        {
+            var instance = new Mock<ILifetimeScope>().Object;
+
+            var context = new OwinContext();
+            context.SetAutofacLifetimeScope(instance);
+            Assert.Same(instance, context.GetAutofacLifetimeScope());
+        }
+
+        [Fact]
+        public async void ScopeSetBySetAutofacLifetimeScopeIsntDisposed()
+        {
+            var lifetimeScope = new Mock<ILifetimeScope>();
+            using (var server = TestServer.Create(app =>
+            {
+                app.Use((ctx, next) =>
+                {
+                    ctx.SetAutofacLifetimeScope(lifetimeScope.Object);
+                    return next();
+                });
+                app.Run(context => context.Response.WriteAsync("Hello, world!"));
+            }))
+            {
+                await server.HttpClient.GetAsync("/");
+            }
+            lifetimeScope.Verify(s => s.Dispose(), Times.Never);
         }
     }
 }


### PR DESCRIPTION
A proposal for #10: allowing to directly set lifetime scope to OWIN context:

```
app
  .Use((ctx, next) =>
  {
    ctx.SetAutofactLifetimeScope(SomeScopeProvider(ctx));
    return next();
  }
  .UseAutofacLifetimeScopeInjector(container)
  .UseMiddlewareFromContainer<PathRewriter>();
```