### PR TITLE
Adding ability to inject IOwinContext into externally created scope

### DIFF
--- a/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
@@ -404,7 +404,7 @@ namespace Owin
                 var lifetimeScope = scopeProvider(context);
                 try
                 {
-                    context.Set(Constants.OwinLifetimeScopeKey, lifetimeScope);
+                    context.SetAutofacLifetimeScope(lifetimeScope);
                     await next();
                 }
                 finally

--- a/src/Autofac.Integration.Owin/OwinContextExtensions.cs
+++ b/src/Autofac.Integration.Owin/OwinContextExtensions.cs
@@ -20,7 +20,7 @@ namespace Autofac.Integration.Owin
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             return context.Get<ILifetimeScope>(Constants.OwinLifetimeScopeKey);
@@ -39,12 +39,12 @@ namespace Autofac.Integration.Owin
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             if (scope == null)
             {
-                throw new ArgumentNullException("scope");
+                throw new ArgumentNullException(nameof(scope));
             }
 
             context.Set(Constants.OwinLifetimeScopeKey, scope);


### PR DESCRIPTION
Added `IAppBuilder.RegisterOwinContext` extension method to allow to inject `IOwinContext` into externally created lifetime scope in the same manner as `UseAutofacLifetimeScopeInjector` does it for self-created scopes.

Also a couple of small style fixes.