### PR TITLE
Resolve versioning issue in the nuspec file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  package_semantic_version: 5.0.0
-  assembly_semantic_version: 5.0.0
+  package_semantic_version: 5.0.1
+  assembly_semantic_version: 5.0.1
 
 version: $(package_semantic_version).{build}
 

--- a/src/Autofac.Integration.Owin/Autofac.Integration.Owin.nuspec
+++ b/src/Autofac.Integration.Owin/Autofac.Integration.Owin.nuspec
@@ -14,7 +14,7 @@
     <iconUrl>https://cloud.githubusercontent.com/assets/1156571/13684110/16b8f152-e6bf-11e5-84ae-22c66c6d351a.png</iconUrl>
     <releaseNotes>Release notes are at https://github.com/autofac/Autofac.Owin/releases</releaseNotes>
     <dependencies>
-      <dependency id="Autofac" version="[3.5.0,5.0.0)" />
+      <dependency id="Autofac" version="[5.0.0,6.0.0)" />
       <dependency id="Microsoft.Owin" version="[3.0.0,5.0.0)" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Failed to update the nuspec constraint in the original 5.0.0 release.

Corrected the constraint and upped the fix version in the appveyor file.