### PR TITLE
CLS Compliance = false + major version bump.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  package_semantic_version: 5.0.1
-  assembly_semantic_version: 5.0.1
+  package_semantic_version: 6.0.0
+  assembly_semantic_version: 6.0.0
 
 version: $(package_semantic_version).{build}
 

--- a/src/Autofac.Integration.Owin/Autofac.Integration.Owin.nuspec
+++ b/src/Autofac.Integration.Owin/Autofac.Integration.Owin.nuspec
@@ -14,7 +14,7 @@
     <iconUrl>https://cloud.githubusercontent.com/assets/1156571/13684110/16b8f152-e6bf-11e5-84ae-22c66c6d351a.png</iconUrl>
     <releaseNotes>Release notes are at https://github.com/autofac/Autofac.Owin/releases</releaseNotes>
     <dependencies>
-      <dependency id="Autofac" version="[5.0.0,6.0.0)" />
+      <dependency id="Autofac" version="[5.0.0,7.0.0)" />
       <dependency id="Microsoft.Owin" version="[3.0.0,5.0.0)" />
     </dependencies>
   </metadata>

--- a/src/Autofac.Integration.Owin/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Integration.Owin/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Autofac.Integration.Owin.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001008728425885ef385e049261b18878327dfaaf0d666dea3bd2b0e4f18b33929ad4e5fbc9087e7eda3c1291d2de579206d9b4292456abffbe8be6c7060b36da0c33b883e3878eaf7c89fddf29e6e27d24588e81e86f3a22dd7b1a296b5f06fbfb500bbd7410faa7213ef4e2ce7622aefc03169b0324bcd30ccfe9ac8204e4960be6")]
 [assembly: InternalsVisibleTo("Autofac.Integration.WebApi.Owin.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001008728425885ef385e049261b18878327dfaaf0d666dea3bd2b0e4f18b33929ad4e5fbc9087e7eda3c1291d2de579206d9b4292456abffbe8be6c7060b36da0c33b883e3878eaf7c89fddf29e6e27d24588e81e86f3a22dd7b1a296b5f06fbfb500bbd7410faa7213ef4e2ce7622aefc03169b0324bcd30ccfe9ac8204e4960be6")]
 [assembly: ComVisible(false)]
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]
 [assembly: AssemblyCompany("Autofac Project - https://autofac.org")]
 [assembly: AssemblyProduct("Autofac")]
 [assembly: AssemblyTrademark("")]


### PR DESCRIPTION
Same as WebApi. Code is compatible already with v6, apart from CLS Compliance.

Increased upper range of the nuspec restriction and incremented the major version.