### PR TITLE
Remove LifetimeScope from OwinContext after it is done being used

### DIFF
--- a/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
+++ b/src/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
@@ -413,6 +413,8 @@ namespace Owin
                     {
                         lifetimeScope?.Dispose();
                     }
+
+                    context.RemoveAutofacLifetimeScope();
                 }
             });
 

--- a/src/Autofac.Integration.Owin/OwinContextExtensions.cs
+++ b/src/Autofac.Integration.Owin/OwinContextExtensions.cs
@@ -50,5 +50,22 @@ namespace Autofac.Integration.Owin
             context.Set(Constants.OwinLifetimeScopeKey, scope);
         }
 
+        /// <summary>
+        /// Removes the Autofac lifetime scope from the OWIN context if it is present.
+        /// </summary>
+        /// <param name="context">The OWIN context.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown if <paramref name="context" /> is <see langword="null" />.
+        /// </exception>
+        /// <remarks>The caller is responsible for the appropriate disposal of the passed <see cref="ILifetimeScope"/>.</remarks>
+        public static void RemoveAutofacLifetimeScope(this IOwinContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            
+            context.Environment.Remove(Constants.OwinLifetimeScopeKey);
+        }
     }
 }

--- a/src/Autofac.Integration.Owin/OwinContextExtensions.cs
+++ b/src/Autofac.Integration.Owin/OwinContextExtensions.cs
@@ -64,7 +64,7 @@ namespace Autofac.Integration.Owin
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            
+
             context.Environment.Remove(Constants.OwinLifetimeScopeKey);
         }
     }

--- a/src/Autofac.Integration.Owin/OwinContextExtensions.cs
+++ b/src/Autofac.Integration.Owin/OwinContextExtensions.cs
@@ -57,7 +57,6 @@ namespace Autofac.Integration.Owin
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="context" /> is <see langword="null" />.
         /// </exception>
-        /// <remarks>The caller is responsible for the appropriate disposal of the passed <see cref="ILifetimeScope"/>.</remarks>
         public static void RemoveAutofacLifetimeScope(this IOwinContext context)
         {
             if (context == null)

--- a/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Owin;
 using Microsoft.Owin.Testing;
 using Moq;
@@ -22,6 +24,13 @@ namespace Autofac.Integration.Owin.Test
         public void GetAutofacLifetimeScopeThrowsWhenProvidedNullInstance()
         {
             var exception = Assert.Throws<ArgumentNullException>(() => OwinContextExtensions.GetAutofacLifetimeScope(null));
+            Assert.Equal("context", exception.ParamName);
+        }
+
+        [Fact]
+        public void RemoveAutofacLifetimeScopeThrowsWhenProvidedNullInstance()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => OwinContextExtensions.RemoveAutofacLifetimeScope(null));
             Assert.Equal("context", exception.ParamName);
         }
 
@@ -54,10 +63,32 @@ namespace Autofac.Integration.Owin.Test
         public void GetAutofacLifetimeScopeReturnsTheInstanceFromSetLifetimeScope()
         {
             var instance = new Mock<ILifetimeScope>().Object;
-
             var context = new OwinContext();
             context.SetAutofacLifetimeScope(instance);
             Assert.Same(instance, context.GetAutofacLifetimeScope());
+        }
+
+        [Fact]
+        public void RemoveAutofacLifetimeScopeRemovesScopeFromContext()
+        {
+            //var scope = new Mock<ILifetimeScope>().Object;
+            //var context = new Mock<IOwinContext>();
+            //var environment = new Mock<IDictionary<string, object>>();
+
+            //context.Setup(mock => mock.Set(Constants.OwinLifetimeScopeKey, scope));
+            //context.Setup(mock => mock.Environment).Returns(environment.Object);
+            //environment.Setup(mock => mock.Remove(Constants.OwinLifetimeScopeKey));
+            //context.Object.SetAutofacLifetimeScope(scope);
+            //context.Object.RemoveAutofacLifetimeScope();
+
+            //context.VerifyAll();
+        }
+
+        [Fact]
+        public void RemoveAutofacLifetimeScopeDoesNotThrowIfScopeNotPresent()
+        {
+            var context = new OwinContext();
+            context.RemoveAutofacLifetimeScope();
         }
 
         [Fact]

--- a/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
@@ -71,17 +71,17 @@ namespace Autofac.Integration.Owin.Test
         [Fact]
         public void RemoveAutofacLifetimeScopeRemovesScopeFromContext()
         {
-            //var scope = new Mock<ILifetimeScope>().Object;
-            //var context = new Mock<IOwinContext>();
-            //var environment = new Mock<IDictionary<string, object>>();
+            var scope = new Mock<ILifetimeScope>().Object;
+            var context = new Mock<IOwinContext>();
+            var environment = new Mock<IDictionary<string, object>>();
 
-            //context.Setup(mock => mock.Set(Constants.OwinLifetimeScopeKey, scope));
-            //context.Setup(mock => mock.Environment).Returns(environment.Object);
-            //environment.Setup(mock => mock.Remove(Constants.OwinLifetimeScopeKey));
-            //context.Object.SetAutofacLifetimeScope(scope);
-            //context.Object.RemoveAutofacLifetimeScope();
+            context.Setup(mock => mock.Set(Constants.OwinLifetimeScopeKey, scope));
+            context.Setup(mock => mock.Environment).Returns(environment.Object);
+            environment.Setup(mock => mock.Remove(Constants.OwinLifetimeScopeKey));
+            context.Object.SetAutofacLifetimeScope(scope);
+            context.Object.RemoveAutofacLifetimeScope();
 
-            //context.VerifyAll();
+            context.VerifyAll();
         }
 
         [Fact]


### PR DESCRIPTION
See title, the idea here is to remove the LifetimeScope from the OwinContext.Environment so that it is no longer referenced and can be garbage collected earlier.

This PR is to resolve the issue filed [here](https://github.com/autofac/Autofac.Owin/issues/25).