### PR TITLE
Fix analyzer references in projects

### DIFF
--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -4,15 +4,21 @@
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <Rule Id="CA1707" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
     <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
     <Rule Id="CA1816" Action="None" />
     <!-- Mark members static - test methods may not access member data but also can't be static. -->
     <Rule Id="CA1822" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Do not directly await a task - this is for libraries rather than test code. -->
+    <Rule Id="CA2007" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Use Uri instead of string parameters - strings are easier for testing. -->
+    <Rule Id="CA2234" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">

--- a/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
+++ b/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
@@ -54,12 +54,6 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="[6.0.0, 7.0.0)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
+++ b/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
@@ -8,6 +8,7 @@
     <SignAssembly>true</SignAssembly>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -23,10 +24,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Autofac.Integration.Owin\Autofac.Integration.Owin.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\build\icon.png" Pack="true" PackagePath="\" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderRunExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderRunExtensionsFixture.cs
@@ -36,7 +36,7 @@ public class AutofacAppBuilderRunExtensionsFixture
         instance.Verify();
     }
 
-    public interface ITestComponent
+    private interface ITestComponent
     {
         Task InvokeAsync(IOwinContext owinContext);
     }


### PR DESCRIPTION
Bit of a "whoops" on my part based on the previous PR to get things building in .NET 6. Just noticed it as I was updating another net472 project.

- In .NET 6 you don't have to reference the analyzer NuGet packages unless you're trying to "pin" versions of the analyzers. It's easier if we let them auto-upgrade. Removed that.
- The unit test project had packaging details (README, icon) in it but isn't packaged. Copy/paste oops.
- The unit test project did not have `AllEnabledByDefault` on, so it was only doing minimal analysis. Turning that on revealed we had a few rules for tests turned up more than we need, but also that there were a few things that needed to be fixed from a code perspective.

This is more in line with how we need to get other net472 projects updated, I think, and I'll be using this in Autofac.Mvc.Owin as I update that one.