### PR TITLE
Switch version compatibilty to using latest Autofac

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "6.0.301"
+    "version": "7.0.100"
   }
 }

--- a/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
+++ b/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="7.0.0" />
+    <PackageReference Include="Autofac" Version="6.0.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
+++ b/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="[6.0.0, 7.0.0)" />
+    <PackageReference Include="Autofac" Version="7.0.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
+++ b/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="3.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />


### PR DESCRIPTION
Don't use a range any more, I'm struggling to think of a good reason to maintain a range restriction.