### PR TITLE
Convert from Moq to NSubstitute

### DIFF
--- a/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
+++ b/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <Using Include="Microsoft.Owin" />
     <Using Include="Microsoft.Owin.Testing" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="Owin" />
     <Using Include="Xunit" />
   </ItemGroup>
@@ -42,7 +42,7 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="3.0.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
@@ -463,14 +463,22 @@ public class AutofacAppBuilderExtensionsFixture
         app.Properties.Returns(new Dictionary<string, object>());
         app.Use(Arg.Any<object>(), Arg.Any<object[]>()).Returns(callInfo =>
         {
-            traceSet.Add((Type)callInfo[0]);
+            if (callInfo[0] is Type t)
+            {
+                traceSet.Add(t);
+            }
+
             return app;
         });
 
         app.UseAutofacMiddleware(container);
 
+        var autofacMiddleware = traceSet
+            .Where(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(AutofacMiddleware<>))
+            .ToList();
+
         Assert.Collection(
-            traceSet,
+            autofacMiddleware,
             item => Assert.Equal(typeof(AutofacMiddleware<TracingTestMiddleware<int>>), item),
             item => Assert.Equal(typeof(AutofacMiddleware<TracingTestMiddleware<bool>>), item),
             item => Assert.Equal(typeof(AutofacMiddleware<TracingTestMiddleware<string>>), item));

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
+// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
@@ -110,7 +110,8 @@ public class AutofacAppBuilderExtensionsFixture
             });
 
             // We don't expect anything to be called on this one, so we want it to fail.
-            app.UseAutofacLifetimeScopeInjector(new Mock<ILifetimeScope>(MockBehavior.Strict).Object);
+            var strictScope = Substitute.For<ILifetimeScope>();
+            app.UseAutofacLifetimeScopeInjector(strictScope);
             app.Use<TestMiddleware>();
             app.Run(context => context.Response.WriteAsync("Hello, world!"));
         }))
@@ -131,7 +132,8 @@ public class AutofacAppBuilderExtensionsFixture
                 ctx.SetAutofacLifetimeScope(lifetimeScope);
                 return next();
             });
-            app.UseAutofacLifetimeScopeInjector(new Mock<ILifetimeScope>(MockBehavior.Strict).Object);
+            var strictScope = Substitute.For<ILifetimeScope>();
+            app.UseAutofacLifetimeScopeInjector(strictScope);
             app.Use<TestMiddleware>();
             app.Run(context => context.Response.WriteAsync("Hello, world!"));
         }))
@@ -152,7 +154,8 @@ public class AutofacAppBuilderExtensionsFixture
             app.UseAutofacLifetimeScopeInjector(container);
 
             // We don't expect anything to be called on this one, so we want it to fail.
-            app.UseAutofacLifetimeScopeInjector(new Mock<ILifetimeScope>(MockBehavior.Strict).Object);
+            var strictScope = Substitute.For<ILifetimeScope>();
+            app.UseAutofacLifetimeScopeInjector(strictScope);
             app.Run(context => context.Response.WriteAsync("Hello, world!"));
         }))
         {
@@ -165,8 +168,8 @@ public class AutofacAppBuilderExtensionsFixture
     {
         var container = new ContainerBuilder().Build();
 
-        var disposable = new Mock<IDisposable>();
-        var asyncDisposable = new Mock<IAsyncDisposable>();
+        var disposable = Substitute.For<IDisposable>();
+        var asyncDisposable = Substitute.For<IAsyncDisposable>();
 
         using (var server = TestServer.Create(app =>
         {
@@ -175,8 +178,8 @@ public class AutofacAppBuilderExtensionsFixture
             {
                 var disposer = ctx.GetAutofacLifetimeScope().Disposer;
 
-                disposer.AddInstanceForDisposal(disposable.Object);
-                disposer.AddInstanceForAsyncDisposal(asyncDisposable.Object);
+                disposer.AddInstanceForDisposal(disposable);
+                disposer.AddInstanceForAsyncDisposal(asyncDisposable);
 
                 return next();
             });
@@ -186,8 +189,8 @@ public class AutofacAppBuilderExtensionsFixture
             await server.HttpClient.GetAsync("/");
         }
 
-        disposable.Verify(d => d.Dispose());
-        asyncDisposable.Verify(d => d.DisposeAsync());
+        disposable.Received().Dispose();
+        await asyncDisposable.Received().DisposeAsync();
     }
 
     [Fact]
@@ -283,7 +286,7 @@ public class AutofacAppBuilderExtensionsFixture
             app.UseAutofacLifetimeScopeInjector(ctx =>
             {
                 Assert.IsAssignableFrom<IOwinContext>(ctx);
-                return new Mock<ILifetimeScope>().Object;
+                return Substitute.For<ILifetimeScope>();
             });
             app.Run(context => context.Response.WriteAsync("Hello, world!"));
         }))
@@ -314,25 +317,25 @@ public class AutofacAppBuilderExtensionsFixture
         var builder = new ContainerBuilder();
         builder.RegisterType<TestMiddleware>();
         var container = builder.Build();
-        var app = new Mock<IAppBuilder>();
-        app.Setup(mock => mock.Properties).Returns(new Dictionary<string, object>());
-        app.SetReturnsDefault(app.Object);
+        var app = Substitute.For<IAppBuilder>();
+        app.Properties.Returns(new Dictionary<string, object>());
+        app.Use(Arg.Any<object>(), Arg.Any<object[]>()).Returns(app);
 
-        app.Object.UseAutofacLifetimeScopeInjector(container);
+        app.UseAutofacLifetimeScopeInjector(container);
 
-        app.Verify(mock => mock.Use(It.IsAny<AutofacMiddleware<TestMiddleware>>(), It.IsAny<object[]>()), Times.Never);
+        app.DidNotReceive().Use(Arg.Is<object>(o => o is AutofacMiddleware<TestMiddleware>), Arg.Any<object[]>());
     }
 
     [Fact]
     public void UseAutofacLifetimeScopeInjectorShowsInjectorRegistered()
     {
-        var app = new Mock<IAppBuilder>();
-        app.Setup(mock => mock.Properties).Returns(new Dictionary<string, object>());
-        app.SetReturnsDefault(app.Object);
+        var app = Substitute.For<IAppBuilder>();
+        app.Properties.Returns(new Dictionary<string, object>());
+        app.Use(Arg.Any<object>(), Arg.Any<object[]>()).Returns(app);
 
         var container = new ContainerBuilder().Build();
-        app.Object.UseAutofacLifetimeScopeInjector(container);
-        Assert.True(app.Object.IsAutofacLifetimeScopeInjectorRegistered());
+        app.UseAutofacLifetimeScopeInjector(container);
+        Assert.True(app.IsAutofacLifetimeScopeInjectorRegistered());
     }
 
     [Fact]
@@ -359,50 +362,49 @@ public class AutofacAppBuilderExtensionsFixture
         var builder = new ContainerBuilder();
         builder.RegisterType<TestMiddleware>();
         var container = builder.Build();
-        var app = new Mock<IAppBuilder>();
-        app.Setup(mock => mock.Properties).Returns(new Dictionary<string, object>());
-        app.Setup(mock => mock.Use(typeof(AutofacMiddleware<TestMiddleware>)));
-        app.SetReturnsDefault(app.Object);
+        var app = Substitute.For<IAppBuilder>();
+        app.Properties.Returns(new Dictionary<string, object>());
+        app.Use(Arg.Any<object>(), Arg.Any<object[]>()).Returns(app);
 
-        app.Object.UseAutofacMiddleware(container);
+        app.UseAutofacMiddleware(container);
 
-        app.VerifyAll();
+        app.Received().Use(typeof(AutofacMiddleware<TestMiddleware>));
     }
 
     [Fact]
     public void UseAutofacMiddlewareShowsInjectorRegistered()
     {
-        var app = new Mock<IAppBuilder>();
-        app.Setup(mock => mock.Properties).Returns(new Dictionary<string, object>());
-        app.SetReturnsDefault(app.Object);
+        var app = Substitute.For<IAppBuilder>();
+        app.Properties.Returns(new Dictionary<string, object>());
+        app.Use(Arg.Any<object>(), Arg.Any<object[]>()).Returns(app);
 
         var container = new ContainerBuilder().Build();
-        app.Object.UseAutofacMiddleware(container);
-        Assert.True(app.Object.IsAutofacLifetimeScopeInjectorRegistered());
+        app.UseAutofacMiddleware(container);
+        Assert.True(app.IsAutofacLifetimeScopeInjectorRegistered());
     }
 
     [Fact]
     public void UseMiddlewareFromContainerAddsSingleWrappedMiddlewareInstanceToAppBuilder()
     {
-        var app = new Mock<IAppBuilder>();
-        app.Setup(mock => mock.Properties).Returns(new Dictionary<string, object>());
-        app.SetReturnsDefault(app.Object);
+        var app = Substitute.For<IAppBuilder>();
+        app.Properties.Returns(new Dictionary<string, object>());
+        app.Use(Arg.Any<object>(), Arg.Any<object[]>()).Returns(app);
 
         var container = new ContainerBuilder().Build();
-        app.Object.UseAutofacLifetimeScopeInjector(container);
-        app.Object.UseMiddlewareFromContainer<TestMiddleware>();
+        app.UseAutofacLifetimeScopeInjector(container);
+        app.UseMiddlewareFromContainer<TestMiddleware>();
 
-        app.Verify(mock => mock.Use(typeof(AutofacMiddleware<TestMiddleware>)), Times.Once);
+        app.Received(1).Use(typeof(AutofacMiddleware<TestMiddleware>));
     }
 
     [Fact]
     public void UseMiddlewareFromContainerRequiresInjectorRegistrationFirst()
     {
-        var app = new Mock<IAppBuilder>();
-        app.Setup(mock => mock.Properties).Returns(new Dictionary<string, object>());
-        app.SetReturnsDefault(app.Object);
+        var app = Substitute.For<IAppBuilder>();
+        app.Properties.Returns(new Dictionary<string, object>());
+        app.Use(Arg.Any<object>(), Arg.Any<object[]>()).Returns(app);
 
-        Assert.Throws<InvalidOperationException>(() => app.Object.UseMiddlewareFromContainer<TestMiddleware>());
+        Assert.Throws<InvalidOperationException>(() => app.UseMiddlewareFromContainer<TestMiddleware>());
     }
 
     [Fact]
@@ -457,13 +459,15 @@ public class AutofacAppBuilderExtensionsFixture
         builder.RegisterType<TracingTestMiddleware<string>>();
 
         var container = builder.Build();
-        var app = new Mock<IAppBuilder>();
-        app.Setup(mock => mock.Properties).Returns(new Dictionary<string, object>());
-        app.Setup(mock => mock.Use(It.IsAny<object>()))
-           .Callback<object, object[]>((m, _) => traceSet.Add((Type)m));
-        app.SetReturnsDefault(app.Object);
+        var app = Substitute.For<IAppBuilder>();
+        app.Properties.Returns(new Dictionary<string, object>());
+        app.Use(Arg.Any<object>(), Arg.Any<object[]>()).Returns(callInfo =>
+        {
+            traceSet.Add((Type)callInfo[0]);
+            return app;
+        });
 
-        app.Object.UseAutofacMiddleware(container);
+        app.UseAutofacMiddleware(container);
 
         Assert.Collection(
             traceSet,

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderRunExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderRunExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
+// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Autofac.Integration.Owin.Test;
@@ -8,21 +8,21 @@ public class AutofacAppBuilderRunExtensionsFixture
     [Fact]
     public void RunFromContainerRequiresInjectorRegistrationFirst()
     {
-        var app = new Mock<IAppBuilder>();
-        app.Setup(mock => mock.Properties).Returns(new Dictionary<string, object>());
-        app.SetReturnsDefault(app.Object);
+        var app = Substitute.For<IAppBuilder>();
+        app.Properties.Returns(new Dictionary<string, object>());
+        app.Use(Arg.Any<object>(), Arg.Any<object[]>()).Returns(app);
 
-        Assert.Throws<InvalidOperationException>(() => app.Object.RunFromContainer<ITestComponent>((component, owinContext) => component.InvokeAsync(owinContext)));
+        Assert.Throws<InvalidOperationException>(() => app.RunFromContainer<ITestComponent>((component, owinContext) => component.InvokeAsync(owinContext)));
     }
 
     [Fact]
     public async Task RunFromContainerResolvesFromLifetimeScope()
     {
-        var instance = new Mock<ITestComponent>();
-        instance.Setup(c => c.InvokeAsync(It.IsAny<IOwinContext>())).Returns(Task.FromResult(0)).Verifiable();
+        var instance = Substitute.For<ITestComponent>();
+        instance.InvokeAsync(Arg.Any<IOwinContext>()).Returns(Task.FromResult(0));
 
         var builder = new ContainerBuilder();
-        builder.RegisterInstance(instance.Object);
+        builder.RegisterInstance(instance);
         using (var server = TestServer.Create(app =>
         {
             app
@@ -33,7 +33,7 @@ public class AutofacAppBuilderRunExtensionsFixture
             await server.HttpClient.GetAsync("/");
         }
 
-        instance.Verify();
+        await instance.Received(1).InvokeAsync(Arg.Any<IOwinContext>());
     }
 
     internal interface ITestComponent

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderRunExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderRunExtensionsFixture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Autofac.Integration.Owin.Test;

--- a/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Autofac Project. All rights reserved.
+// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Autofac.Integration.Owin.Test;
@@ -8,10 +8,9 @@ public class OwinContextExtensionsFixture
     [Fact]
     public void GetAutofacLifetimeScopeReturnsInstanceFromContext()
     {
-        var context = new Mock<IOwinContext>();
-        context.Setup(mock => mock.Get<ILifetimeScope>(Constants.OwinLifetimeScopeKey));
-        context.Object.GetAutofacLifetimeScope();
-        context.VerifyAll();
+        var context = Substitute.For<IOwinContext>();
+        context.GetAutofacLifetimeScope();
+        context.Received().Get<ILifetimeScope>(Constants.OwinLifetimeScopeKey);
     }
 
     [Fact]
@@ -31,18 +30,17 @@ public class OwinContextExtensionsFixture
     [Fact]
     public void SetAutofacLifetimeScopeSetsInstanceToContext()
     {
-        var instance = new Mock<ILifetimeScope>();
+        var instance = Substitute.For<ILifetimeScope>();
 
-        var context = new Mock<IOwinContext>();
-        context.Setup(mock => mock.Set(Constants.OwinLifetimeScopeKey, instance.Object));
-        context.Object.SetAutofacLifetimeScope(instance.Object);
-        context.VerifyAll();
+        var context = Substitute.For<IOwinContext>();
+        context.SetAutofacLifetimeScope(instance);
+        context.Received().Set(Constants.OwinLifetimeScopeKey, instance);
     }
 
     [Fact]
     public void SetAutofacLifetimeScopeThrowsWhenProvidedNullContextInstance()
     {
-        var exception = Assert.Throws<ArgumentNullException>(() => OwinContextExtensions.SetAutofacLifetimeScope(null, new Mock<ILifetimeScope>().Object));
+        var exception = Assert.Throws<ArgumentNullException>(() => OwinContextExtensions.SetAutofacLifetimeScope(null, Substitute.For<ILifetimeScope>()));
         Assert.Equal("context", exception.ParamName);
     }
 
@@ -56,7 +54,7 @@ public class OwinContextExtensionsFixture
     [Fact]
     public void GetAutofacLifetimeScopeReturnsTheInstanceFromSetLifetimeScope()
     {
-        var instance = new Mock<ILifetimeScope>().Object;
+        var instance = Substitute.For<ILifetimeScope>();
         var context = new OwinContext();
         context.SetAutofacLifetimeScope(instance);
         Assert.Same(instance, context.GetAutofacLifetimeScope());
@@ -65,17 +63,16 @@ public class OwinContextExtensionsFixture
     [Fact]
     public void RemoveAutofacLifetimeScopeRemovesScopeFromContext()
     {
-        var scope = new Mock<ILifetimeScope>().Object;
-        var context = new Mock<IOwinContext>();
-        var environment = new Mock<IDictionary<string, object>>();
+        var scope = Substitute.For<ILifetimeScope>();
+        var context = Substitute.For<IOwinContext>();
+        var environment = Substitute.For<IDictionary<string, object>>();
 
-        context.Setup(mock => mock.Set(Constants.OwinLifetimeScopeKey, scope));
-        context.Setup(mock => mock.Environment).Returns(environment.Object);
-        environment.Setup(mock => mock.Remove(Constants.OwinLifetimeScopeKey));
-        context.Object.SetAutofacLifetimeScope(scope);
-        context.Object.RemoveAutofacLifetimeScope();
+        context.Environment.Returns(environment);
+        context.SetAutofacLifetimeScope(scope);
+        context.RemoveAutofacLifetimeScope();
 
-        context.VerifyAll();
+        context.Received().Set(Constants.OwinLifetimeScopeKey, scope);
+        environment.Received().Remove(Constants.OwinLifetimeScopeKey);
     }
 
     [Fact]
@@ -88,12 +85,12 @@ public class OwinContextExtensionsFixture
     [Fact]
     public async void ScopeSetBySetAutofacLifetimeScopeIsNotDisposed()
     {
-        var lifetimeScope = new Mock<ILifetimeScope>();
+        var lifetimeScope = Substitute.For<ILifetimeScope>();
         using (var server = TestServer.Create(app =>
         {
             app.Use((ctx, next) =>
             {
-                ctx.SetAutofacLifetimeScope(lifetimeScope.Object);
+                ctx.SetAutofacLifetimeScope(lifetimeScope);
                 return next();
             });
             app.Run(context => context.Response.WriteAsync("Hello, world!"));
@@ -102,6 +99,6 @@ public class OwinContextExtensionsFixture
             await server.HttpClient.GetAsync("/");
         }
 
-        lifetimeScope.Verify(s => s.Dispose(), Times.Never);
+        lifetimeScope.DidNotReceive().Dispose();
     }
 }

--- a/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Autofac Project. All rights reserved.
+﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 namespace Autofac.Integration.Owin.Test;


### PR DESCRIPTION
## Summary
- Replace Moq with NSubstitute 5.3.0
- Convert 3 test files with Setup/Verify/Callback/SetReturnsDefault patterns to NSubstitute equivalents
- Part of cross-repo effort to standardize on NSubstitute

## Test plan
- [ ] CI build passes (net472 project, cannot build locally on macOS)