### PR TITLE
Update target framework to net481

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
-    <Version>7.1.0</Version>
+    <Version>8.0.0</Version>
     <SolutionName>Autofac.Owin</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
+++ b/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
@@ -15,7 +15,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <NoWarn>$(NoWarn);NU1903</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -55,13 +55,13 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.5.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin" Version="[3.0.0, 5.0.0)" />

--- a/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
+++ b/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Autofac" Version="7.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
+++ b/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -39,15 +39,14 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="7.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Microsoft.Owin.Testing" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
@@ -79,7 +79,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorAddsChildLifetimeScopeToOwinContext()
+    public async Task UseAutofacLifetimeScopeInjectorAddsChildLifetimeScopeToOwinContext()
     {
         var builder = new ContainerBuilder();
         builder.RegisterType<TestMiddleware>();
@@ -98,7 +98,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorDoesntOverrideScopeSetBySetAutofacLifetimeScope()
+    public async Task UseAutofacLifetimeScopeInjectorDoesntOverrideScopeSetBySetAutofacLifetimeScope()
     {
         using var lifetimeScope = new TestableLifetimeScope();
         using (var server = TestServer.Create(app =>
@@ -122,7 +122,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorDoesntDisposeScopeSetBySetAutofacLifetimeScope()
+    public async Task UseAutofacLifetimeScopeInjectorDoesntDisposeScopeSetBySetAutofacLifetimeScope()
     {
         using var lifetimeScope = new TestableLifetimeScope();
         using (var server = TestServer.Create(app =>
@@ -145,7 +145,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorDoesntAddLifetimeScopeToOwinContextIfAlreadyPresent()
+    public async Task UseAutofacLifetimeScopeInjectorDoesntAddLifetimeScopeToOwinContextIfAlreadyPresent()
     {
         var container = new ContainerBuilder().Build();
 
@@ -164,7 +164,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorDisposesIt()
+    public async Task UseAutofacLifetimeScopeInjectorDisposesIt()
     {
         var container = new ContainerBuilder().Build();
 
@@ -194,7 +194,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void RemoveAutofacLifetimeScopeAfterUse()
+    public async Task RemoveAutofacLifetimeScopeAfterUse()
     {
         var builder = new ContainerBuilder();
         builder.RegisterType<TestMiddleware>();
@@ -228,7 +228,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void RemoveAutofacLifetimeScopeAfterUseWhenExceptionThrown()
+    public async Task RemoveAutofacLifetimeScopeAfterUseWhenExceptionThrown()
     {
         var builder = new ContainerBuilder();
         builder.RegisterType<TestMiddleware>();
@@ -263,7 +263,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorWithExternalScopeAddsItToOwinContext()
+    public async Task UseAutofacLifetimeScopeInjectorWithExternalScopeAddsItToOwinContext()
     {
         using var lifetimeScope = new TestableLifetimeScope();
         using (var server = TestServer.Create(app =>
@@ -279,7 +279,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorWithExternalScopePassesOwinContextToTheProvider()
+    public async Task UseAutofacLifetimeScopeInjectorWithExternalScopePassesOwinContextToTheProvider()
     {
         using (var server = TestServer.Create(app =>
         {
@@ -296,7 +296,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorWithExternalScopeDoesntDisposeIt()
+    public async Task UseAutofacLifetimeScopeInjectorWithExternalScopeDoesntDisposeIt()
     {
         using var lifetimeScope = new TestableLifetimeScope();
         using (var server = TestServer.Create(app =>
@@ -339,7 +339,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacMiddlewareAddsChildLifetimeScopeToOwinContext()
+    public async Task UseAutofacMiddlewareAddsChildLifetimeScopeToOwinContext()
     {
         var builder = new ContainerBuilder();
         builder.RegisterType<TestMiddleware>();
@@ -408,7 +408,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorWithContainerRegistersOwinContextInTheScope()
+    public async Task UseAutofacLifetimeScopeInjectorWithContainerRegistersOwinContextInTheScope()
     {
         using (var server = TestServer.Create(app =>
         {
@@ -428,7 +428,7 @@ public class AutofacAppBuilderExtensionsFixture
     }
 
     [Fact]
-    public async void UseAutofacLifetimeScopeInjectorWithExternalScopeDoesNotRegisterOwinContextInTheScope()
+    public async Task UseAutofacLifetimeScopeInjectorWithExternalScopeDoesNotRegisterOwinContextInTheScope()
     {
         using (var server = TestServer.Create(app =>
         {

--- a/test/Autofac.Integration.Owin.Test/AutofacMiddlewareFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacMiddlewareFixture.cs
@@ -6,7 +6,7 @@ namespace Autofac.Integration.Owin.Test;
 public class AutofacMiddlewareFixture
 {
     [Fact]
-    public async void MiddlewareMustBeRegistered()
+    public async Task MiddlewareMustBeRegistered()
     {
         var builder = new ContainerBuilder();
         var container = builder.Build();

--- a/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/OwinContextExtensionsFixture.cs
@@ -83,7 +83,7 @@ public class OwinContextExtensionsFixture
     }
 
     [Fact]
-    public async void ScopeSetBySetAutofacLifetimeScopeIsNotDisposed()
+    public async Task ScopeSetBySetAutofacLifetimeScopeIsNotDisposed()
     {
         var lifetimeScope = Substitute.For<ILifetimeScope>();
         using (var server = TestServer.Create(app =>


### PR DESCRIPTION
## Summary
- Update target framework from `net472` to `net481` (.NET Framework 4.8.1)
- Bump version from 7.1.0 to 8.0.0 (breaking change: minimum framework requirement)
- Update Microsoft.SourceLink.GitHub to 8.0.0, StyleCop.Analyzers to 1.2.0-beta.556, Microsoft.NETFramework.ReferenceAssemblies to 1.0.3
- Update test infrastructure: xunit 2.9.3, Microsoft.NET.Test.Sdk 18.0.0, xunit.runner.visualstudio 3.1.5, Microsoft.Owin.Testing 4.2.3
- Remove unnecessary System.Diagnostics.DiagnosticSource from test project
- Fix `async void` test methods to `async Task` (xUnit1048)

## Test plan
- [ ] CI build passes
- [ ] All tests pass on net481