### PR TITLE
Technology refresh: update dependencies

### DIFF
--- a/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
+++ b/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
@@ -14,7 +14,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
     <TargetFramework>net481</TargetFramework>
-    <NoWarn>$(NoWarn);NU1900;NU1903</NoWarn>
+    <NoWarn>$(NoWarn);NU1903</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
+++ b/src/Autofac.Integration.Owin/Autofac.Integration.Owin.csproj
@@ -14,7 +14,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
     <TargetFramework>net481</TargetFramework>
-    <NoWarn>$(NoWarn);NU1903</NoWarn>
+    <NoWarn>$(NoWarn);NU1900;NU1903</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -52,11 +52,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="6.5.0" />
+    <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
+++ b/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net481</TargetFramework>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU1900</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -37,10 +37,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="7.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
     <PackageReference Include="Microsoft.Owin.Testing" Version="4.2.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
+++ b/test/Autofac.Integration.Owin.Test/Autofac.Integration.Owin.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net481</TargetFramework>
-    <NoWarn>$(NoWarn);CS1591;NU1900</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
+++ b/test/Autofac.Integration.Owin.Test/AutofacAppBuilderExtensionsFixture.cs
@@ -549,7 +549,7 @@ public class AutofacAppBuilderExtensionsFixture
             throw new NotImplementedException();
         }
 
-        public object ResolveComponent(ResolveRequest request)
+        public object ResolveComponent(in ResolveRequest request)
         {
             ResolveOperationBeginning(this, null);
             throw new NotImplementedException();


### PR DESCRIPTION
## Summary
- Updated Autofac from 6.5.0 to 9.1.0
- Updated Microsoft.SourceLink.GitHub from 8.0.0 to 10.0.300
- Updated System.Diagnostics.DiagnosticSource from 8.0.1 to 10.0.0 (required by Autofac 9.1.0)
- Updated test mock to use 'in' parameter for ResolveComponent to match Autofac 9.1.0 API

## Test plan
- [x] Build succeeds with zero warnings
- [x] All 39 unit tests pass